### PR TITLE
Improved image display

### DIFF
--- a/index.html
+++ b/index.html
@@ -694,7 +694,7 @@
                                     <div style="display: flex; align-items: center; cursor: pointer; cursor: pointer;" onclick="$( '.blank_view' ).style.display = 'none';$( '.store_products' ).style.display = 'flex';"><div style="display: flex; align-items: center; font-weight: bold; font-size: 3rem; margin-right: 0.5rem;"></div><div style="font-weight: bold; font-size: 2rem;">⇦</div></div>
                                     <div style="font-weight: bold;">Product</div>
                                     <div><span class="product_name"></span></div><br>
-                                    <img class="product_image" style="border: 1px solid black; width: 100%; margin: auto;"><br><br>
+                                    <img class="product_image" style="border: 1px solid black; width: auto; margin-left: 0;"><br><br>
                                     <div style="font-weight: bold;">Price</div>
                                     <div class="product_price"></div><br>
                                     <div style="font-weight: bold;">Description</div>

--- a/styles.css
+++ b/styles.css
@@ -566,7 +566,7 @@ button:hover {
 .product_image {
   border: 1px solid #E0E0E0;
   width: 100%;
-  height: 200px;
+  min-height: 200px;
   object-fit: cover;
   object-position: center;
   margin: 0 auto 16px;


### PR DESCRIPTION
Every shop has different image sizes. Nevertheless, product details should be fully visible, even on the detail page. My change is just an idea to improve the display of the images. Maybe it works. I'm not a developer.

Please also try my changes with this address:
https://zapit.store/index.html?pubkey=02bfd76bc6973738e5757b372cf4d700a5fb729cb5c7b9083eaa909c70e1f0ff99&relays=%5B%22wss://nostrue.com%22,%22wss://relay.wellorder.net%22,%22wss://relay.damus.io%22%5D
